### PR TITLE
feat: error on face matcher response JSON structure

### DIFF
--- a/face_matcher/main.cpp
+++ b/face_matcher/main.cpp
@@ -91,7 +91,12 @@ int main(int argc, char* argv[]) {
         cv::Mat img1 = cv::imread(image1_path);
         cv::Mat img2 = cv::imread(image2_path);
         if (img1.empty() || img2.empty()) {
-            std::cerr << "Error: Error reading images." << std::endl;
+            std::cout << "{"
+                    << "\"distance\":" << 1 << ", "
+                    << "\"requestId\":" << requestId << ", "
+                    << "\"match\":false, "
+                    << "\"error\":\"Error reading images.\""
+                    << "}" << std::endl;
             continue;
         }
 
@@ -101,7 +106,12 @@ int main(int argc, char* argv[]) {
 
         // Ensure faces are detected in both images
         if (extracted_faces_1.empty() || extracted_faces_2.empty()) {
-            std::cerr << "Error: No faces detected in one or both images." << std::endl;
+            std::cout << "{"
+                    << "\"distance\":" << 1 << ", "
+                    << "\"requestId\":" << requestId << ", "
+                    << "\"match\":false, "
+                    << "\"error\":\"No faces detected in one or both images.\""
+                    << "}" << std::endl;
             continue;
         }
 
@@ -116,7 +126,12 @@ int main(int argc, char* argv[]) {
         } else if (distance_algorithm == "euclidean") {
             distance = findEuclideanDistance(pred1, pred2);
         } else {
-            std::cerr << "Error: Unknown distance algorithm: " << distance_algorithm << std::endl;
+            std::cout << "{"
+                    << "\"distance\":" << 1 << ", "
+                    << "\"requestId\":" << requestId << ", "
+                    << "\"match\":false, "
+                    << "\"error\":\"Unknown distance algorithm: " << distance_algorithm << "\""
+                    << "}" << std::endl;
             continue;
         }
 
@@ -124,9 +139,11 @@ int main(int argc, char* argv[]) {
         bool match = (distance < distance_threshold);
 
         // Output the response
-        std::cout << "Response: {distance:" << distance
-                  << ", requestId:" << requestId
-                  << ", match:" << (match ? "true" : "false") << "}" << std::endl;
+        std::cout << "{"
+                << "\"distance\":" << distance << ", "
+                << "\"requestId\":" << requestId << ", "
+                << "\"match\":" << (match ? "true" : "false")
+                << "}" << std::endl;
     }
 
     return 0;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,6 +37,7 @@ export interface FaceMatchResponse {
   match: boolean
   distance: number
   requestId: number
+  error?: string
 }
 
 /**


### PR DESCRIPTION
Introduces a new output behaviour for face matcher process:

- It will write in stderr **only** in unexpected cases where it is impossible to determine the _requestId_, like wrong input format structure
- It will output on stdout in all other cases, even if errors occur, as long as requestId is identifiable. The output now is fully JSON compliant and adds an optional `error` field. This facilitates the parsing from NodeJS

When the face matcher process writes in stderr we will consider that something unexpected happened, so we'll attempt to exit the process and restart it (alongisde the queue), so the whole service recovers automatically.

Mainly, the reason for this change is that currently we don't have any feedback when errors happen: process listener is only catching stdout and, if anything wrong happens such as no faces detected in an image, the process will timeout and the queue will be stuck because it won't get any feedback about the ending of the task. As a result, the whole service is blocked until it is restarted (#32).

Since this solves a major problem we are facing in our demos, we need to have this merged ASAP. 

cc @diegoalfonsoaguilarcardona 
