### PR TITLE
feat: Ingress on the Helm chart configurable via enabled flag

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,3 +1,31 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ tpl .Values.ingress.name . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - {{ tpl .Values.ingress.host . }}
+      secretName: {{ tpl .Values.ingress.tlsSecret . }}
+  rules:
+    - host: {{ tpl .Values.ingress.host . }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.service.name }}
+                port:
+                  number: {{ .Values.service.ports.app }}
+---
+{{- end }}
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,8 +36,8 @@ spec:
     app: {{ .Values.app.name }}
   ports:
     - protocol: TCP
-      port: {{ .Values.service.ports.redis }}
-      targetPort: {{ .Values.service.ports.redis }}
+      port: {{ .Values.service.ports.app }}
+      targetPort: {{ .Values.service.ports.app }}
 
 ---
 
@@ -34,7 +62,7 @@ spec:
           image: io2060/vision-matcher:{{ .Chart.Version }}
           imagePullPolicy: {{ .Values.statefulset.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.service.ports.redis }}
+            - containerPort: {{ .Values.service.ports.app }}
           resources:
             requests:
               memory: {{ .Values.statefulset.resources.requests.memory | quote }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,3 +1,5 @@
+global:
+  domain: dev.example.io  
 
 app:
   name: vision-matcher
@@ -20,4 +22,10 @@ statefulset:
 service:
   name: vision-matcher-service
   ports:
-    redis: 5123
+    app: 5123
+
+ingress:
+  enabled: true
+  name: vision-matcher-ingress
+  host: vm.{{ .Values.global.domain }}
+  tlsSecret: vm.{{ .Values.global.domain }}-cert


### PR DESCRIPTION

- Render Ingress only when `ingress.enabled=true`
- Add Global domain to use accoring to branch
-  Update Service/StatefulSet to use the new port key (app)
-  BREAKING CHANGE: `service.ports.redis` -> `service.ports.app`. Update your values files accordingly.

Close #40  
Close #41 